### PR TITLE
Telepen numeric support

### DIFF
--- a/examples/webpack+js/index.html
+++ b/examples/webpack+js/index.html
@@ -31,6 +31,7 @@
         <label for="AllowedEanExtensions">AllowedEanExtensions:</label><input type="text" name="AllowedEanExtensions"
           id="AllowedEanExtensions" />
         <label for="AlsoInverted">AlsoInverted:</label><input type="checkbox" name="AlsoInverted" id="AlsoInverted" />
+        <label for="TelepenAsNumeric">TelepenAsNumeric:</label><input type="checkbox" name="TelepenAsNumeric" id="TelepenAsNumeric" />
       </div>
       <input type="file" id="image_file_input" />
       <button id="scan_btn" disabled="true">Scan</button>

--- a/examples/webpack+js/index.js
+++ b/examples/webpack+js/index.js
@@ -1,7 +1,7 @@
 import { convert_js_image_to_luma, decode_barcode_with_hints, DecodeHintDictionary, DecodeHintTypes, BarcodeFormat } from "rxing-wasm";
 
 const text_hints = ["Other", "PossibleFormats", "CharacterSet", "AllowedLengths", "AllowedEanExtensions"];
-const bool_hints = ["PureBarcode", "TryHarder", "AssumeCode39CheckDigit", "ReturnCodabarStartEnd", "AssumeGs1", "AlsoInverted"]
+const bool_hints = ["PureBarcode", "TryHarder", "AssumeCode39CheckDigit", "ReturnCodabarStartEnd", "AssumeGs1", "AlsoInverted", "TelepenAsNumeric"]
 
 const scan_btn = document.getElementById('scan_btn');
 const input = document.getElementById('image_file_input');

--- a/src/decode_hints.rs
+++ b/src/decode_hints.rs
@@ -76,6 +76,12 @@ pub enum DecodeHintTypes {
      * second time with an inverted image. Doesn't matter what it maps to; use {@link Boolean#TRUE}.
      */
     AlsoInverted,
+
+
+    /**
+     * Translate the ASCII values parsed by the Telepen reader into the Telepen Numeric form; use {@link Boolean#TRUE}.
+     */
+    TelepenAsNumeric,
 }
 
 impl From<DecodeHintTypes> for rxing::DecodeHintType {
@@ -99,6 +105,7 @@ impl From<DecodeHintTypes> for rxing::DecodeHintType {
             }
             DecodeHintTypes::AllowedEanExtensions => rxing::DecodeHintType::ALLOWED_EAN_EXTENSIONS,
             DecodeHintTypes::AlsoInverted => rxing::DecodeHintType::ALSO_INVERTED,
+            DecodeHintTypes::TelepenAsNumeric => rxing::DecodeHintType::TELEPEN_AS_NUMERIC,
         }
     }
 }
@@ -236,6 +243,13 @@ impl DecodeHintDictionary {
                     hint.into(),
                     rxing::DecodeHintValue::AlsoInverted(also_inverted),
                 );
+            }
+            DecodeHintTypes::TelepenAsNumeric => {
+                let Ok(telepen_as_numeric) = value.parse() else {
+                    return false;
+                };
+                self.0
+                    .insert(hint.into(), rxing::DecodeHintValue::TelepenAsNumeric(telepen_as_numeric));
             }
         }
         true


### PR DESCRIPTION
Following on from the change in the main library to support Telepen, I'm currently unable to decode Telepen Numeric barcodes without the following changes to allow the hint to be passed through.

I've also updated the demo site so that this can be set too.