### PR TITLE
Small improvements

### DIFF
--- a/src/encode_hints.rs
+++ b/src/encode_hints.rs
@@ -1,5 +1,5 @@
 use rxing::{datamatrix::encoder::SymbolShapeHint, Dimension};
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ pub fn decode_barcode(
 /// Such an object could be obtained using the `getImageData`
 /// method of a `CanvasRenderingContext2D` object.
 pub fn convert_js_image_to_luma(data: &[u8]) -> Vec<u8> {
-    let mut luma_data = Vec::new();
+    let mut luma_data = Vec::with_capacity(data.len() / 4);
     for src_pixel in data.chunks_exact(4) {
         let [red, green, blue, alpha] = src_pixel else {
             continue;


### PR DESCRIPTION
1. Remove an unused `use` (thanks, `cargo fix`)
2. Use `Vec::with_capacity()` in `convert_js_image_to_luma()`

Thank you for the library!